### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Cross-Platform Test Matrix
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Klest94/Bellatrex/security/code-scanning/5](https://github.com/Klest94/Bellatrex/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` and before the `on` block. This will apply the permission restriction to all jobs in the workflow unless overridden at the job level. No changes to the jobs or steps are required, as none of the current steps require write access to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
