### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage-parity.yml
+++ b/.github/workflows/coverage-parity.yml
@@ -1,5 +1,7 @@
 # .github/workflows/coverage-parity.yml
 name: Coverage (consistent between local and Codecov)
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/KlestDedja/Bellatrex/security/code-scanning/6](https://github.com/KlestDedja/Bellatrex/security/code-scanning/6)

The best way to fix the issue is to explicitly set a `permissions` block at the workflow (root) level in `.github/workflows/coverage-parity.yml`. This will ensure that all jobs in the workflow default to the minimal necessary permissions for the GITHUB_TOKEN. Based on the workflow, `contents: read` is sufficient, as no step writes to the repository through the GITHUB_TOKEN. Place the following block right after the workflow `name:` declaration:

```yaml
permissions:
  contents: read
```

No extra imports, method definitions, or additional code changes elsewhere are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
