### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage-parity.yml
+++ b/.github/workflows/coverage-parity.yml
@@ -1,6 +1,9 @@
 # .github/workflows/coverage-parity.yml
 name: Coverage (consistent between local and Codecov)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/KlestDedja/Bellatrex/security/code-scanning/7](https://github.com/KlestDedja/Bellatrex/security/code-scanning/7)

To fix the problem, add an explicit `permissions` section to the workflow to restrict the GITHUB_TOKEN to the least privilege needed. In this case, none of the steps appear to require write access to repository contents or any repository-level artifacts. Therefore, the workflow-level (global) `permissions` block, set to `contents: read`, is sufficient and is the minimal safe default.  

**How to fix:**
- Add a `permissions:` block at the top level (just after or before the `on:` block, and before `jobs:`) with `contents: read`.
- This block ensures that the GITHUB_TOKEN granted to all jobs in this workflow is limited to read-only access to repository contents.
- No additional imports, methods, or definitions are needed.

**File/region to change:**
- Only make changes to `.github/workflows/coverage-parity.yml`.
- Insert the minimal `permissions:` block near the top (conventionally after the `name:` and before `on:` or after `on:` but before `jobs:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
